### PR TITLE
Add missing include

### DIFF
--- a/src-qt5/drawablepage.h
+++ b/src-qt5/drawablepage.h
@@ -1,6 +1,7 @@
 #ifndef LUMINA_PDF_DRAWABLEPAGE_H
 #define LUMINA_PDF_DRAWABLEPAGE_H
 
+#include <memory>
 #include <QImage>
 #include <QSize>
 #include <poppler/qt5/poppler-qt5.h>


### PR DESCRIPTION
std::unique_ptr defined in <memory>, so we need to include it, avoiding ugly compilation errors.