### PR TITLE
Rewrite zoom. Add a QComboBox to choose some current zoom level 

### DIFF
--- a/src-qt5/mainUI.cpp
+++ b/src-qt5/mainUI.cpp
@@ -157,10 +157,10 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
     }
     BACKEND->setDegrees(90);
   });
-  QObject::connect(ui->actionZoom_In_2, &QAction::triggered, WIDGET,
-                   [&] { WIDGET->zoomIn(1.2); });
-  QObject::connect(ui->actionZoom_Out_2, &QAction::triggered, WIDGET,
-                   [&] { WIDGET->zoomOut(1.2); });
+  QObject::connect(ui->actionZoom_In_2, SIGNAL(triggered()), this,
+                   SLOT(zoomIn()));
+  QObject::connect(ui->actionZoom_Out_2, SIGNAL(triggered()), this,
+                   SLOT(zoomOut()));
   QObject::connect(ui->actionFirst_Page, SIGNAL(triggered()), this,
                    SLOT(firstPage()));
   QObject::connect(ui->actionPrevious_Page, SIGNAL(triggered()), this,
@@ -809,6 +809,54 @@ void MainUI::gotoPage() {
                                          tr("Page number:"), 1, 1, BACKEND->numPages(), 1, &ok);
     if (ok)
         ShowPage(page);
+}
+
+void MainUI::zoomIn() {
+  if (zoomPercent->findText( zoomPercent->currentText() ) == -1 ) {
+      double percentage = zoomPercent->currentText().remove('%').toDouble() * 1.2 / 100;
+      WIDGET->fitView();
+      WIDGET->zoomIn( percentage );
+      zoomPercent->lineEdit()->setText(QString::number(percentage * 100.0, 'f', 2) + QString(" %"));
+  }
+  else {
+    switch( zoomPercent->currentData().toInt() ) {
+    case -2:
+    case -1:
+      WIDGET->zoomIn( 1.2 );
+      zoomPercent->lineEdit()->setText(QString("120 %"));
+      break;
+    default:
+      double percentage = zoomPercent->currentData().toInt() * 1.2 / 100;
+      WIDGET->fitView();
+      WIDGET->zoomIn( percentage );
+      zoomPercent->lineEdit()->setText(QString::number(percentage * 100.0, 'f', 2) + QString(" %"));
+      break;
+    }
+  }
+}
+
+void MainUI::zoomOut() {
+  if (zoomPercent->findText( zoomPercent->currentText() ) == -1 ) {
+      double percentage = zoomPercent->currentText().remove('%').toDouble() / 1.2 / 100;
+      WIDGET->fitView();
+      WIDGET->zoomIn( percentage );
+      zoomPercent->lineEdit()->setText(QString::number(percentage * 100.0, 'f', 2) + QString(" %"));
+  }
+  else {
+    switch( zoomPercent->currentData().toInt() ) {
+    case -2:
+    case -1:
+      WIDGET->zoomIn( 1.2 );
+      zoomPercent->lineEdit()->setText(QString("120 %"));
+      break;
+    default:
+      double percentage = zoomPercent->currentData().toInt() / 1.2 / 100;
+      WIDGET->fitView();
+      WIDGET->zoomIn( percentage );
+      zoomPercent->lineEdit()->setText(QString::number(percentage * 100.0, 'f', 2) + QString(" %"));
+      break;
+    }
+  }
 }
 
 void MainUI::onZoomPageIndexChanged() {

--- a/src-qt5/mainUI.cpp
+++ b/src-qt5/mainUI.cpp
@@ -98,8 +98,8 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
 
   zoomPercent = new QComboBox(this);
   zoomPercent->setEditable(true);
-  zoomPercent->addItem(tr("Fit width"), -2);
-  zoomPercent->addItem(tr("Fit page"), -1);
+  zoomPercent->addItem(tr("Fit page"), -2);
+  zoomPercent->addItem(tr("Fit width"), -1);
   zoomPercent->addItem(tr("25 %"), 25);
   zoomPercent->addItem(tr("50 %"), 50);
   zoomPercent->addItem(tr("75 %"), 75);
@@ -109,9 +109,9 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
   zoomPercent->addItem(tr("300 %"), 300);
   zoomPercent->addItem(tr("400 %"), 400);
   zoomPercent->addItem(tr("500 %"), 500);
+  zoomPercent->setCurrentIndex(0);
   zoomPercent->setInsertPolicy(QComboBox::NoInsert);
   zoomPercent->setInputMethodHints(Qt::ImhDigitsOnly);
-  zoomPercent->setCurrentIndex(1);
   ui->toolBar->insertWidget(ui->actionZoom_In_2, zoomPercent);
 
   // Put the various actions into logical groups
@@ -865,10 +865,10 @@ void MainUI::onZoomPageIndexChanged() {
   switch (zoomPercent->currentData().toInt())
   {
     case -2:
-      WIDGET->fitToWidth();
+      WIDGET->fitView();
       break;
     case -1:
-      WIDGET->fitView();
+      WIDGET->fitToWidth();
       break;
     default:
       WIDGET->fitView();

--- a/src-qt5/mainUI.cpp
+++ b/src-qt5/mainUI.cpp
@@ -96,6 +96,21 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
   pageAct = ui->toolBar->insertWidget(ui->actionNext_Page,label_page);
   pageAct->setVisible(false);
 
+  QComboBox *zoomPercent = new QComboBox(this);
+  zoomPercent->setEditable(true);
+  zoomPercent->addItem(tr("Fit width"), 0);
+  zoomPercent->addItem(tr("Fit page"), 1);
+  zoomPercent->addItem(tr("25 %"), 25);
+  zoomPercent->addItem(tr("50 %"), 50);
+  zoomPercent->addItem(tr("75 %"), 75);
+  zoomPercent->addItem(tr("100 %"), 100);
+  zoomPercent->addItem(tr("150 %"), 150);
+  zoomPercent->addItem(tr("200 %"), 200);
+  zoomPercent->addItem(tr("300 %"), 300);
+  zoomPercent->addItem(tr("400 %"), 400);
+  zoomPercent->addItem(tr("500 %"), 500);
+  ui->toolBar->addWidget(zoomPercent);
+
   // Put the various actions into logical groups
   QActionGroup *tmp = new QActionGroup(this);
   tmp->setExclusive(true);
@@ -164,6 +179,8 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
                    SLOT(lastPage()));
   QObject::connect(ui->actionGoTo_Page, SIGNAL(triggered()), this,
                    SLOT(gotoPage()));
+  QObject::connect(zoomPercent, qOverload<int>(&QComboBox::currentIndexChanged),
+                   [=](int index) { onZoomPageIndexChanged(zoomPercent->currentData().toInt()); });
   QObject::connect(ui->actionProperties, &QAction::triggered, WIDGET,
                    [&] { PROPDIALOG->show(); });
   QObject::connect(BACKEND, &Renderer::OrigSize, this,
@@ -801,6 +818,21 @@ void MainUI::gotoPage() {
     if (ok)
         ShowPage(page);
 }
+
+void MainUI::onZoomPageIndexChanged(int index) {
+
+  if ( index == -1 ) {
+    return;
+  } else if ( index == 0 ) { // fit width
+    WIDGET->fitToWidth();
+  } else if ( index == 1 ) { // fit page
+    WIDGET->fitView();
+  } else {
+    WIDGET->fitView();
+    WIDGET->zoomIn(index / 100.0);
+  }
+}
+
 void MainUI::find(QString text, bool forward) {
   if (!text.isEmpty()) {
     static bool previousMatchCase = matchCase;

--- a/src-qt5/mainUI.cpp
+++ b/src-qt5/mainUI.cpp
@@ -111,6 +111,7 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
   zoomPercent->addItem(tr("500 %"), 500);
   zoomPercent->setInsertPolicy(QComboBox::NoInsert);
   zoomPercent->setInputMethodHints(Qt::ImhDigitsOnly);
+  zoomPercent->setCurrentIndex(1);
   ui->toolBar->insertWidget(ui->actionZoom_In_2, zoomPercent);
 
   // Put the various actions into logical groups

--- a/src-qt5/mainUI.cpp
+++ b/src-qt5/mainUI.cpp
@@ -111,16 +111,10 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
   zoomPercent->addItem(tr("500 %"), 500);
   zoomPercent->setInsertPolicy(QComboBox::NoInsert);
   zoomPercent->setInputMethodHints(Qt::ImhDigitsOnly);
-  ui->toolBar->addWidget(zoomPercent);
+  ui->toolBar->insertWidget(ui->actionZoom_In_2, zoomPercent);
 
   // Put the various actions into logical groups
   QActionGroup *tmp = new QActionGroup(this);
-  tmp->setExclusive(true);
-  tmp->addAction(ui->actionFit_Width);
-  tmp->addAction(ui->actionFit_Page);
-  ui->actionFit_Page->setChecked(true);
-
-  tmp = new QActionGroup(this);
   tmp->setExclusive(true);
   tmp->addAction(ui->actionSingle_Page);
   tmp->addAction(ui->actionDual_Pages);
@@ -135,10 +129,6 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
   QObject::connect(ui->actionClose, SIGNAL(triggered()), this, SLOT(close()));
   QObject::connect(ui->actionPrint, SIGNAL(triggered()), PrintDLG,
                    SLOT(open()));
-  QObject::connect(ui->actionFit_Width, SIGNAL(triggered()), WIDGET,
-                   SLOT(fitToWidth()));
-  QObject::connect(ui->actionFit_Page, SIGNAL(triggered()), WIDGET,
-                   SLOT(fitView()));
   QObject::connect(ui->actionOpen_PDF, SIGNAL(triggered()), this,
                    SLOT(OpenNewFile()));
   QObject::connect(ui->actionSingle_Page, SIGNAL(triggered()), WIDGET,
@@ -243,8 +233,6 @@ MainUI::MainUI() : QMainWindow(), ui(new Ui::MainUI()) {
   // Setup all the icons
   ui->actionPrint->setIcon(QIcon::fromTheme("document-print"));
   ui->actionClose->setIcon(QIcon::fromTheme("window-close"));
-  ui->actionFit_Width->setIcon(QIcon::fromTheme("transform-scale"));
-  ui->actionFit_Page->setIcon(QIcon::fromTheme("zoom-fit-best"));
   ui->actionOpen_PDF->setIcon(QIcon::fromTheme("document-open"));
   ui->actionSingle_Page->setIcon( QIcon::fromTheme("view-split-top-bottom", QIcon::fromTheme("format-view-agenda") ));
   ui->actionDual_Pages->setIcon( QIcon::fromTheme("view-split-left-right", QIcon::fromTheme("format-view-grid-small") ));

--- a/src-qt5/mainUI.h
+++ b/src-qt5/mainUI.h
@@ -84,6 +84,8 @@ private slots:
   void nextPage();
   void prevPage();
   void gotoPage();
+  void zoomIn();
+  void zoomOut();
   void onZoomPageIndexChanged();
   void onZoomPageTextChanged();
   void firstPage() { ShowPage(1); }

--- a/src-qt5/mainUI.h
+++ b/src-qt5/mainUI.h
@@ -84,7 +84,8 @@ private slots:
   void nextPage();
   void prevPage();
   void gotoPage();
-  void onZoomPageIndexChanged(int index );
+  void onZoomPageIndexChanged();
+  void onZoomPageTextChanged();
   void firstPage() { ShowPage(1); }
   void lastPage() { ShowPage(BACKEND->numPages()); }
   void startPresentationHere() { startPresentation(false); }

--- a/src-qt5/mainUI.h
+++ b/src-qt5/mainUI.h
@@ -19,6 +19,7 @@
 #include <QProgressBar>
 #include <QTimer>
 #include <QWheelEvent>
+#include <QComboBox>
 
 #include "BookmarkMenu.h"
 #include "PresentationLabel.h"
@@ -57,6 +58,7 @@ private:
   QAction *progAct; // action associated with the progressbar
   QTimer *clockTimer;
   QMenu *contextMenu;
+  QComboBox *zoomPercent;
   // QFrame *frame_presenter;
   QLabel *label_clock, *label_page;
   QAction *clockAct, *pageAct;
@@ -82,6 +84,7 @@ private slots:
   void nextPage();
   void prevPage();
   void gotoPage();
+  void onZoomPageIndexChanged(int index );
   void firstPage() { ShowPage(1); }
   void lastPage() { ShowPage(BACKEND->numPages()); }
   void startPresentationHere() { startPresentation(false); }

--- a/src-qt5/mainUI.ui
+++ b/src-qt5/mainUI.ui
@@ -200,8 +200,6 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="actionFit_Page"/>
-   <addaction name="actionFit_Width"/>
    <addaction name="separator"/>
    <addaction name="actionSingle_Page"/>
    <addaction name="actionDual_Pages"/>
@@ -226,22 +224,6 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Q</string>
-   </property>
-  </action>
-  <action name="actionFit_Page">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Fit Page</string>
-   </property>
-  </action>
-  <action name="actionFit_Width">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Fit Width</string>
    </property>
   </action>
   <action name="actionPrint">
@@ -378,7 +360,7 @@
   </action>
   <action name="actionZoom_Out_2">
    <property name="text">
-    <string/>
+    <string>Zoom Out</string>
    </property>
    <property name="toolTip">
     <string>Zoom Out</string>
@@ -386,7 +368,7 @@
   </action>
   <action name="actionZoom_In_2">
    <property name="text">
-    <string/>
+    <string>Zoom In</string>
    </property>
    <property name="toolTip">
     <string>Zoom In</string>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7521540/67805404-46690380-fa91-11e9-8696-6a1ac0c1fce0.png)

Instead of having 4 buttons, I rewrite the UI inspired by other PDF viewer.
With this PR, we have:
- One combobox with default zoom levels
- Fit Page / Fit Width are inside the combobox and buttons are removed
- Zoom In and Zoom Out are based upon this combobox too. Scale factor is always 1.2 but from the combobox value

If you agree with this new UI/features. I will finish my PR by polish it and fix zoomIn/zoomOut when combobox value is Fit Width.