### PR TITLE
Fix build with Qt 5.14

### DIFF
--- a/src-qt5/Annotation.h
+++ b/src-qt5/Annotation.h
@@ -1,4 +1,5 @@
 #include <QColor>
+#include <QImage>
 #include <QList>
 #include <QPointF>
 #include <QPolygonF>


### PR DESCRIPTION
In file included from Renderer.h:10,
                 from PropDialog.h:9,
                 from PropDialog.cpp:8:
Annotation.h:38:11: error: ‘QImage’ does not name a type